### PR TITLE
Fix encoded translations in returns [1168376234]

### DIFF
--- a/app/assets/javascripts/tolk/actions.js
+++ b/app/assets/javascripts/tolk/actions.js
@@ -100,6 +100,7 @@ $(function () {
         q: q,
         source: 'en',
         target: target,
+        format: 'text'
       });
     })
   }


### PR DESCRIPTION
## Description

Since the translation format is not explicitly provided, the Google Translation API is taking the default format, which is HTML. Hence, it is returning html encoded string as translated text. If the format is explicitly provided as "text", the html encoding will not happen.

## Screenshot
<img width="910" alt="Tolk" src="https://user-images.githubusercontent.com/25539181/112822378-25db1980-9088-11eb-8adf-37b1f6145b86.png">
